### PR TITLE
Remove right shifting by 4 on palette number when computing the spn_bits

### DIFF
--- a/libyaul/scu/bus/b/vdp/vdp2_scrn_cell.c
+++ b/libyaul/scu/bus/b/vdp/vdp2_scrn_cell.c
@@ -305,7 +305,7 @@ vdp2_scrn_pnd_set(const vdp2_scrn_cell_format_t *cell_format)
 
         switch (cell_format->ccc) {
         case VDP2_SCRN_CCC_PALETTE_16:
-            spn_bits = ((palette_number >> 4) & 0x07) << 5;
+            spn_bits = (palette_number & 0x07) << 5;
             break;
         case VDP2_SCRN_CCC_PALETTE_256:
         case VDP2_SCRN_CCC_PALETTE_2048:


### PR DESCRIPTION
The palette number is computed for 16 color palettes by shifting by either 5 or 6 when calling `VDP2_SCRN_PND_MODE_0_PAL_NUM` / `VDP2_SCRN_PND_MODE_1_PAL_NUM` or `VDP2_SCRN_PND_MODE_2_PAL_NUM`. This leaves the remaining 3 bits in the palette_number by the time this is used for calculating the supplementary palette number in `vdp2_scrn_pnd_set`. This changes removes shifting the value by a further 4 bits, as currently this deteriorates bank numbers that sit in this range.

Currently to access the second 16 color CRAM bank you have to set an offset using for example `VDP2_CRAM_MODE_0_OFFSET(0, 16, 0)` after this change you can access the second bank using `VDP2_CRAM_MODE_0_OFFSET(0, 1, 0)`. This change only affects 16 color palettes, although I am not sure if any further parts of yaul touch the spn_bits, or there is a related change required for the cram_offset calculation.