### PR TITLE
Add minor changes

### DIFF
--- a/libyaul/kernel/sys/init.c
+++ b/libyaul/kernel/sys/init.c
@@ -25,6 +25,8 @@ void user_init(void) __weak;
 
 static void _bss_clear(void);
 
+void __weak _early_access() {;}
+
 void __noreturn
 __sys_init(void)
 {
@@ -34,6 +36,8 @@ __sys_init(void)
     void __global_dtors(void) __weak;
 
     _bss_clear();
+
+    _early_access();
 
     __atexit_init();
 

--- a/libyaul/kernel/sys/init.c
+++ b/libyaul/kernel/sys/init.c
@@ -23,9 +23,9 @@
 
 void user_init(void) __weak;
 
-static void _bss_clear(void);
+void user_early_init(void) __weak;
 
-void __weak _early_access() {;}
+static void _bss_clear(void);
 
 void __noreturn
 __sys_init(void)
@@ -37,7 +37,9 @@ __sys_init(void)
 
     _bss_clear();
 
-    _early_access();
+    if (user_early_init != NULL) {
+        user_early_init();
+    }
 
     __atexit_init();
 

--- a/libyaul/kernel/sys/init.h
+++ b/libyaul/kernel/sys/init.h
@@ -19,6 +19,13 @@ __BEGIN_DECLS
 extern "C" void user_init(void);
 #endif /* __cplusplus */
 
+/* This prototype declaration is needed (only) for C++ to void name mangling. We
+ * also don't want to explicitly declare the prototype for C either (hence the
+ * redundant extern "C") */
+#ifdef __cplusplus
+extern "C" void user_early_init(void);
+#endif /* __cplusplus */
+
 __END_DECLS
 
 #endif /* !_YAUL_KERNEL_SYS_INIT_H_ */

--- a/libyaul/scu/bus/b/vdp/vdp1/env.h
+++ b/libyaul/scu/bus/b/vdp/vdp1/env.h
@@ -44,6 +44,13 @@ typedef enum vdp1_env_bpp {
     VDP1_ENV_BPP_8  = 1
 } vdp1_env_bpp_t;
 
+typedef enum vdp1_env_hdtv {
+    /// Not yet documented.
+    VDP1_ENV_HDTV_OFF = 0,
+    /// Not yet documented.
+    VDP1_ENV_HDTV_ON  = 1
+} vdp1_env_hdtv_t;
+
 typedef enum vdp1_env_color_mode {
     /// Not yet documented.
     VDP1_ENV_COLOR_MODE_PALETTE     = 0,
@@ -63,6 +70,7 @@ typedef struct vdp1_env {
         unsigned int :1;
         vdp1_env_bpp_t bpp:1;
         vdp1_env_rotation_t rotation:1;
+        vdp1_env_hdtv_t hdtv:1;
         vdp1_env_color_mode_t color_mode:1;
         vdp2_sprite_type_t sprite_type:4;
     } __packed;

--- a/libyaul/scu/bus/b/vdp/vdp1_env.c
+++ b/libyaul/scu/bus/b/vdp/vdp1_env.c
@@ -75,7 +75,7 @@ vdp1_env_set(const vdp1_env_t *env)
     _env_current_update(env);
 
     /* Always clear TVM and VBE bits */
-    _state_vdp1()->shadow_ioregs.tvmr = (env->hdtv) ? 0x4 : (env->rotation << 1) | env->bpp;
+    _state_vdp1()->shadow_ioregs.tvmr = (env->hdtv) ? (0x4) : ((env->rotation << 1) | env->bpp);
 
     _state_vdp1()->shadow_ioregs.ewdr = env->erase_color.raw;
 

--- a/libyaul/scu/bus/b/vdp/vdp1_env.c
+++ b/libyaul/scu/bus/b/vdp/vdp1_env.c
@@ -75,7 +75,7 @@ vdp1_env_set(const vdp1_env_t *env)
     _env_current_update(env);
 
     /* Always clear TVM and VBE bits */
-    _state_vdp1()->shadow_ioregs.tvmr = (env->rotation << 1) | env->bpp;
+    _state_vdp1()->shadow_ioregs.tvmr = (env->hdtv) ? 0x4 : (env->rotation << 1) | env->bpp;
 
     _state_vdp1()->shadow_ioregs.ewdr = env->erase_color.raw;
 

--- a/libyaul/scu/bus/b/vdp/vdp2_scrn_cell.c
+++ b/libyaul/scu/bus/b/vdp/vdp2_scrn_cell.c
@@ -30,11 +30,11 @@ vdp2_scrn_cell_ccc_set(const vdp2_scrn_cell_format_t *cell_format)
 {
     switch (cell_format->scroll_screen) {
     case VDP2_SCRN_NBG0:
-        _state_vdp2()->shadow_regs.chctla &= 0xFF8F;
+        _state_vdp2()->shadow_regs.chctla &= 0xFF8D;
         _state_vdp2()->shadow_regs.chctla |= cell_format->ccc << 4;
         break;
     case VDP2_SCRN_NBG1:
-        _state_vdp2()->shadow_regs.chctla &= 0xCFFF;
+        _state_vdp2()->shadow_regs.chctla &= 0xCDFF;
         _state_vdp2()->shadow_regs.chctla |= cell_format->ccc << 12;
         break;
     case VDP2_SCRN_NBG2:


### PR DESCRIPTION
1) Added `user_early_init` function that, when overrided, allows user code execution when the SEGA logo is still on screen.
2) Added VDP1 HDTV flag, it allows switching VDP1 into HDTV (480p) modes
3) When setting cell format, `xxBMEN` flag in `CHCTLx` is reset now, allowing switching from bitmap to cell format.